### PR TITLE
Updated intl library version

### DIFF
--- a/scheduled_calendar/example/pubspec.lock
+++ b/scheduled_calendar/example/pubspec.lock
@@ -95,10 +95,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.1"
   lints:
     dependency: transitive
     description:

--- a/scheduled_calendar/example/pubspec.yaml
+++ b/scheduled_calendar/example/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.17.0
+  intl: ^0.18.1
   collection: ^1.17.0
   scheduled_calendar:
     path: ../

--- a/scheduled_calendar/pubspec.yaml
+++ b/scheduled_calendar/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_mobx: ^2.1.0
   infinite_scroll_pagination: ^3.2.0
-  intl: ^0.17.0
+  intl: ^0.18.1
   mobx: ^2.2.0
   provider: ^6.0.5
 


### PR DESCRIPTION
На маркете для локализации нужна intl 0.18.1, из за того что в календаре 0.17.0 - выходят конфликты. Я просто поменял версию intl